### PR TITLE
Add new screen for the first questions

### DIFF
--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -4,6 +4,7 @@ import 'package:contact_assistant/presentation/screens/add_edit_contact_screen.d
 import 'package:contact_assistant/presentation/screens/contact_detail_screen.dart';
 import 'package:contact_assistant/presentation/screens/settings_screen.dart';
 import 'package:contact_assistant/presentation/screens/networking_guide_screen.dart';
+import 'package:contact_assistant/presentation/screens/icebreaker_screen.dart';
 import 'package:contact_assistant/data/models/contact.dart';
 import 'package:contact_assistant/core/services/ai_notes_service.dart';
 import 'package:flutter/material.dart';
@@ -14,6 +15,10 @@ final router = GoRouter(
     GoRoute(
       path: '/',
       builder: (context, state) => const HomeScreen(),
+    ),
+    GoRoute(
+      path: '/icebreaker',
+      builder: (context, state) => const IcebreakerScreen(),
     ),
     GoRoute(
       path: '/add_contact',

--- a/lib/core/services/ai_notes_service.dart
+++ b/lib/core/services/ai_notes_service.dart
@@ -22,8 +22,16 @@ class AiNotesService {
       "emotional connection or offer a chance to be helpful. "
       "Return a JSON object with a key 'questions' containing a list of strings.";
 
+  static const String _icebreakerInstruction =
+      "You are an expert networker like Keith Ferrazzi. The user is about to meet someone new. "
+      "The context of the meeting is provided by the user. Generate 4 highly engaging, authentic "
+      "icebreaker questions to start the conversation. AVOID boring questions like 'What do you do?'. "
+      "Focus on finding their 'Blue Flame' (passions), current challenges, or personal stories. "
+      "Return a JSON object with a key 'questions' containing a list of strings.";
+
   late final GenerativeModel _model;
   late final GenerativeModel _networkingModel;
+  late final GenerativeModel _icebreakerModel;
 
   AiNotesService._internal() {
     _model = FirebaseAI.googleAI().generativeModel(
@@ -36,6 +44,13 @@ class AiNotesService {
     _networkingModel = FirebaseAI.googleAI().generativeModel(
       model: 'gemini-2.5-flash',
       systemInstruction: Content.system(_networkingInstruction),
+      generationConfig: GenerationConfig(
+        responseMimeType: 'application/json',
+      ),
+    );
+    _icebreakerModel = FirebaseAI.googleAI().generativeModel(
+      model: 'gemini-2.5-flash',
+      systemInstruction: Content.system(_icebreakerInstruction),
       generationConfig: GenerationConfig(
         responseMimeType: 'application/json',
       ),
@@ -119,7 +134,29 @@ class AiNotesService {
     final List<dynamic> questions = data['questions'] ?? [];
     return questions.map((e) => e.toString()).toList();
   }
+
+  /// Generates 4 icebreaker questions for a new encounter.
+  Future<List<String>> generateIcebreakers(String context) async {
+    final response = await _icebreakerModel.generateContent([
+      Content.text(context),
+    ]);
+
+    final jsonText = response.text;
+    if (jsonText == null || jsonText.trim().isEmpty) {
+      throw Exception('Gemini returned an empty response.');
+    }
+
+    final Map<String, dynamic> data;
+    try {
+      data = jsonDecode(jsonText) as Map<String, dynamic>;
+    } on FormatException catch (e) {
+      throw Exception('Gemini returned invalid JSON: $e');
+    }
+    final List<dynamic> questions = data['questions'] ?? [];
+    return questions.map((e) => e.toString()).toList();
+  }
 }
+
 
 class FerrazziProfile {
   final String family;

--- a/lib/core/services/ai_notes_service.dart
+++ b/lib/core/services/ai_notes_service.dart
@@ -152,8 +152,15 @@ class AiNotesService {
     } on FormatException catch (e) {
       throw Exception('Gemini returned invalid JSON: $e');
     }
-    final List<dynamic> questions = data['questions'] ?? [];
-    return questions.map((e) => e.toString()).toList();
+    final rawQuestions = data['questions'];
+    if (rawQuestions is! List) {
+      throw Exception("Gemini JSON must contain a 'questions' array.");
+    }
+    final questions = rawQuestions
+        .map((e) => e.toString().trim())
+        .where((q) => q.isNotEmpty)
+        .toList();
+    return questions;
   }
 }
 

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -31,6 +31,13 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         title: const Text('Personal CRM'),
         actions: [
           IconButton(
+            icon: const Icon(Icons.lightbulb),
+            tooltip: 'New Acquaintance Guide',
+            onPressed: () {
+              context.push('/icebreaker');
+            },
+          ),
+          IconButton(
             icon: const Icon(Icons.settings),
             onPressed: () {
               context.push('/settings');

--- a/lib/presentation/screens/icebreaker_screen.dart
+++ b/lib/presentation/screens/icebreaker_screen.dart
@@ -13,9 +13,9 @@ class IcebreakerScreen extends StatefulWidget {
 class _IcebreakerScreenState extends State<IcebreakerScreen> {
   final TextEditingController _contextController = TextEditingController();
   List<String> _questions = [
-    "Що зараз забирає найбільше вашої уваги та енергії?",
-    "Якби ви могли змінити одну річ у своїй індустрії, що б це було?",
-    "Що вас найбільше драйвить у вільний час?"
+    "What is currently taking up most of your attention and energy?",
+    "If you could change one thing about your industry, what would it be?",
+    "What do you enjoy doing most in your free time?"
   ];
   bool _isLoading = false;
   String? _error;
@@ -31,6 +31,13 @@ class _IcebreakerScreenState extends State<IcebreakerScreen> {
     if (contextText.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Please enter a meeting context')),
+      );
+      return;
+    }
+    if (contextText.length > 500) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content: Text('Please keep context under 500 characters')),
       );
       return;
     }
@@ -90,6 +97,7 @@ class _IcebreakerScreenState extends State<IcebreakerScreen> {
                     border: OutlineInputBorder(),
                   ),
                   maxLines: null,
+                  maxLength: 500,
                 ),
                 const SizedBox(height: 16),
                 ElevatedButton.icon(
@@ -135,7 +143,8 @@ class _IcebreakerScreenState extends State<IcebreakerScreen> {
                                 children: [
                                   Icon(
                                     _getIconForQuestion(),
-                                    color: Theme.of(context).colorScheme.primary,
+                                    color:
+                                        Theme.of(context).colorScheme.primary,
                                     size: 28,
                                   ),
                                   const SizedBox(width: 16),
@@ -166,7 +175,7 @@ class _IcebreakerScreenState extends State<IcebreakerScreen> {
           padding: const EdgeInsets.all(16.0),
           child: ElevatedButton.icon(
             onPressed: () {
-               context.push('/add_contact');
+              context.push('/add_contact');
             },
             icon: const Icon(Icons.add),
             label: const Text('Add as New Contact'),

--- a/lib/presentation/screens/icebreaker_screen.dart
+++ b/lib/presentation/screens/icebreaker_screen.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:go_router/go_router.dart';
+import 'package:contact_assistant/core/services/ai_notes_service.dart';
+
+class IcebreakerScreen extends StatefulWidget {
+  const IcebreakerScreen({super.key});
+
+  @override
+  State<IcebreakerScreen> createState() => _IcebreakerScreenState();
+}
+
+class _IcebreakerScreenState extends State<IcebreakerScreen> {
+  final TextEditingController _contextController = TextEditingController();
+  List<String> _questions = [
+    "Що зараз забирає найбільше вашої уваги та енергії?",
+    "Якби ви могли змінити одну річ у своїй індустрії, що б це було?",
+    "Що вас найбільше драйвить у вільний час?"
+  ];
+  bool _isLoading = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _contextController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _generateStarters() async {
+    final contextText = _contextController.text.trim();
+    if (contextText.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please enter a meeting context')),
+      );
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+
+    try {
+      final qs = await AiNotesService().generateIcebreakers(contextText);
+      if (mounted) {
+        setState(() {
+          _questions = qs;
+          _isLoading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = e.toString();
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  void _copyToClipboard(String text) {
+    Clipboard.setData(ClipboardData(text: text));
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Question copied to clipboard')),
+    );
+  }
+
+  IconData _getIconForQuestion() {
+    return Icons.lightbulb_outline;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('New Acquaintance Guide'),
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                TextField(
+                  controller: _contextController,
+                  decoration: const InputDecoration(
+                    labelText: 'Where are you meeting them?',
+                    hintText: "e.g., Tech Conference, Friend's Party, Airplane",
+                    border: OutlineInputBorder(),
+                  ),
+                  maxLines: null,
+                ),
+                const SizedBox(height: 16),
+                ElevatedButton.icon(
+                  onPressed: _isLoading ? null : _generateStarters,
+                  icon: const Text('✨'),
+                  label: const Text('Generate Starters'),
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const Divider(),
+          Expanded(
+            child: _isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : _error != null
+                    ? Center(
+                        child: Padding(
+                          padding: const EdgeInsets.all(16.0),
+                          child: Text(
+                            'Failed to load questions:\n$_error',
+                            textAlign: TextAlign.center,
+                            style: const TextStyle(color: Colors.red),
+                          ),
+                        ),
+                      )
+                    : ListView.builder(
+                        padding: const EdgeInsets.all(16.0),
+                        itemCount: _questions.length,
+                        itemBuilder: (context, index) {
+                          final question = _questions[index];
+                          return Card(
+                            margin: const EdgeInsets.only(bottom: 16.0),
+                            color: Theme.of(context)
+                                .colorScheme
+                                .surfaceContainerHighest,
+                            child: Padding(
+                              padding: const EdgeInsets.all(16.0),
+                              child: Row(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Icon(
+                                    _getIconForQuestion(),
+                                    color: Theme.of(context).colorScheme.primary,
+                                    size: 28,
+                                  ),
+                                  const SizedBox(width: 16),
+                                  Expanded(
+                                    child: Text(
+                                      question,
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .titleMedium,
+                                    ),
+                                  ),
+                                  IconButton(
+                                    icon: const Icon(Icons.copy),
+                                    onPressed: () => _copyToClipboard(question),
+                                    tooltip: 'Copy',
+                                  ),
+                                ],
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+          ),
+        ],
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: ElevatedButton.icon(
+            onPressed: () {
+               context.push('/add_contact');
+            },
+            icon: const Icon(Icons.add),
+            label: const Text('Add as New Contact'),
+            style: ElevatedButton.styleFrom(
+              padding: const EdgeInsets.symmetric(vertical: 16),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Icebreaker screen reachable from a new "New Acquaintance Guide" button in the home app bar.
  * Enter meeting context to generate AI-powered conversation starters; results show in a scrollable list of cards.
  * Tap an icon to copy individual questions to the clipboard with a confirmation message.
  * Shows loading state and displays errors if generation fails; includes a shortcut to add a contact.
* **Chores**
  * Added a navigation route for the Icebreaker screen and a new service endpoint to generate icebreakers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->